### PR TITLE
Add multi-architecture (AMD64 & ARM64) support for Docker builds

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 node:20-slim
+FROM node:20-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Removes forced --platform=linux/arm64 from the Dockerfile.

Closes #9 